### PR TITLE
Also consider it a crash if doComparison is False and the return code is non-zero

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -223,7 +223,7 @@ class Test(object):
     def crashed(self):
         """ Whether the test crashed or not """
 
-        return len(self.backtrace) > 0 or (self.run_as_script and self.return_code != 0)
+        return len(self.backtrace) > 0 or ((self.run_as_script or (not self.doComparison)) and self.return_code != 0)
 
     @property
     def outfile(self):


### PR DESCRIPTION
We apparently don't consider a non-zero exit code a failure unless `self.run_as_script` is `True`. When doing plotfile comparisons, this isn't a big issue, since the comparison itself will fail as the test did not produce any output. However, when we run through travis we turn off comparisons, so we need to check the exit code. 

An alternative fix would be to consider all non-zero exit codes a failure. In principle I prefer this, but I don't know the reasoning behind the original behavior here, so I'd like to be conservative. 