### PR TITLE
add check_file_name option

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -661,8 +661,8 @@ def test_suite(argv):
 
         if suite.sourceTree == "C_Src" or test.testSrcTree == "C_Src":
 
-            base_cmd = "./{} {} {}={}_plt amr.check_file={}_chk".format(
-                executable, test.inputFile, suite.plot_file_name, test.name, test.name)
+            base_cmd = "./{} {} {}={}_plt {}={}_chk".format(
+                executable, test.inputFile, suite.plot_file_name, suite.check_file_name, test.name, test.name)
 
             # keep around the checkpoint files only for the restart runs
             if test.restartTest:

--- a/suite.py
+++ b/suite.py
@@ -409,6 +409,7 @@ class Suite(object):
         self.slack_username = ""
 
         self.plot_file_name = "amr.plot_file"
+        self.check_file_name = "amr.check_file"
 
         self.globalAddToExecString = ""
 


### PR DESCRIPTION
This lets you set both the plot and chk file argument names in the *.ini file.