### PR TITLE
Fix Warnings: Literal != (2)

### DIFF
--- a/test_report.py
+++ b/test_report.py
@@ -794,11 +794,11 @@ def report_this_test_run(suite, make_benchmarks, note, update_time,
     # summary table
     if make_benchmarks is None:
         special_cols = []
-        if suite.summary_job_info_field1 is not "":
+        if suite.summary_job_info_field1 != "":
             special_cols.append(suite.summary_job_info_field1)
-        if suite.summary_job_info_field2 is not "":
+        if suite.summary_job_info_field2 != "":
             special_cols.append(suite.summary_job_info_field2)
-        if suite.summary_job_info_field3 is not "":
+        if suite.summary_job_info_field3 != "":
             special_cols.append(suite.summary_job_info_field3)
 
         cols = ["test name", "dim", "compare plotfile",
@@ -891,15 +891,15 @@ def report_this_test_run(suite, make_benchmarks, note, update_time,
 
 
             # special columns
-            if suite.summary_job_info_field1 is not "":
+            if suite.summary_job_info_field1 != "":
                 row_info.append("<div class='small'>{}</div>".format(
                     test.job_info_field1))
 
-            if suite.summary_job_info_field2 is not "":
+            if suite.summary_job_info_field2 != "":
                 row_info.append("<div class='small'>{}</div>".format(
                     test.job_info_field2))
 
-            if suite.summary_job_info_field3 is not "":
+            if suite.summary_job_info_field3 != "":
                 row_info.append("<div class='small'>{}</div>".format(
                     test.job_info_field3))
 


### PR DESCRIPTION
Fix warnings of the form:
```
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:797: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field1 is not "":
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:799: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field2 is not "":
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:801: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field3 is not "":
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:894: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field1 is not "":
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:898: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field2 is not "":
/tmp/ci-6TMWVrjtKt/regression_testing/test_report.py:902: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if suite.summary_job_info_field3 is not "":
```

similar to as #2