### PR TITLE
regtest.py: Print Path to Input File

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -586,6 +586,7 @@ def test_suite(argv):
         # copy the necessary files over to the run directory
         #----------------------------------------------------------------------
         suite.log.log("copying files to run directory...")
+        suite.log.log("path to input file: {}".format(test.inputFile))
 
         needed_files = []
         if executable is not None:


### PR DESCRIPTION
I suggest that we print out the complete path to the input file of each test, when running the WarpX CI test suite through `run_test.sh` (both locally and on Azure).

Example:
```
working on test: Langmuir_multi_2d_psatd
   re-making clean...
   building...
   make -j8 AMREX_HOME=/tmp/ci-mcPo5mbrtw/amrex/  DEBUG=FALSE USE_ACC=FALSE USE_MPI=TRUE USE_OMP=TRUE DIM=2 USE_PSATD=TRUE   COMP=g++ TEST=TRUE USE_ASSERTION=TRUE WarpxBinDir= 
   copying files to run directory...
   path to input file: Examples/Tests/Langmuir/inputs_2d_multi_rt
   running the test...
   mpiexec -n 2 ./main2d.gnu.TEST.TPROF.MTMPI.OMP.QED.PSATD.GPUCLOCK.ex inputs_2d_multi_rt  diag1.file_prefix=Langmuir_multi_2d_psatd_plt   amrex.abort_on_unused_inputs=1  algo.maxwell_solver=psatd psatd.fftw_plan_measure=0 diag1.electrons.variables=w ux uy uz diag1.positrons.variables=w ux uy uz diag1.fields_to_plot=Ex Ey Ez jx jy jz part_per_cell warpx.cfl = 0.7071067811865475
   WARNING: unable to open the job_info file
   doing the analysis...
   execution time: 1.7s
   creating problem test report ...
   Langmuir_multi_2d_psatd PASSED
```
where the new line `path to input file: Examples/Tests/Langmuir/inputs_2d_multi_rt` is the one that was added.

In my opinion, this makes it easier to know where to find a given input file, without having to open the file `Regression/WarpX-tests.ini` and look for the `inputFile` parameter of the given test.

Not sure if it is sufficient to modify our fork of the regression suite in order to make this work both on Azure and locally, or if we have to do a similar modification at the AMReX level, since that is the repository that we actually clone.