### PR TITLE
suite.py: Avoid Duplicates in addToCompileString

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -913,6 +913,10 @@ class Suite(object):
                 if not self.repos["source"].comp_string is None:
                     build_opts += self.repos["source"].comp_string + " "
 
+            # Remove duplicate build options from test.addToCompileString to avoid duplicate builds
+            build_opts_new = []
+            [build_opts_new.append(s) for s in test.addToCompileString.split() if s not in build_opts_new]
+            test.addToCompileString = ' '.join(build_opts_new)
             if not test.addToCompileString == "":
                 build_opts += test.addToCompileString + " "
 


### PR DESCRIPTION
This should fix https://github.com/ECP-WarpX/WarpX/issues/2068.

This PR can be tested by running
```
./run_test.sh Langmuir_multi_2d_nodal Langmuir_multi_2d_psatd
```
from a local WarpX installation, with and without the changes in this PR. With the changes in this PR, we avoid two duplicate builds for the two tests above, by removing the duplicate build option `USE_PSATD=TRUE` (otherwise appearing twice) from the final compile string.

Note that you will have to modify [run_test.sh](https://github.com/ECP-WarpX/WarpX/blob/development/run_test.sh) by commenting and replacing the following line
```py
#git clone https://github.com/ECP-WarpX/regression_testing.git
cp -r /<path_to>/regression_testing .
```
in order to use your local clone of the regression testing repository (and thus be able to switch between the master branch and the branch of this PR).