### PR TITLE
Handle customRunCmd in restart tests so we can test restarting through the python inferface.

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -757,6 +757,10 @@ def test_suite(argv):
                 # Copy again runtime_params into restart execution command
                 base_cmd += "{} {}".format(suite.globalAddToExecString, test.runtime_params)
 
+            if test.customRunCmd is not None:
+                base_cmd = test.customRunCmd
+                base_cmd += " amr.restart={}".format(restart_file)
+
             suite.run_test(test, base_cmd)
 
         test.wall_time = time.time() - test.wall_time


### PR DESCRIPTION
This is needed so that we can add a restart test to this WarpX PR: https://github.com/ECP-WarpX/WarpX/pull/2332