### PR TITLE
Fix Bug to Build AMReX Tool particle_compare

### DIFF
--- a/suite.py
+++ b/suite.py
@@ -1030,7 +1030,7 @@ class Suite(object):
 
         for t in ctools:
             self.log.log("building {}...".format(t))
-            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE ")
+            comp_string, rc = self.build_c(opts="DEBUG=FALSE USE_MPI=FALSE EBASE={}".format(t))
             if not rc == 0:
                 self.log.fail("unable to continue, tools not able to be built")
 


### PR DESCRIPTION
This should fix a bug occurring when we try to build the AMReX tool `particle_compare`. Tested locally. Thank you, @atmyers, for suggesting how to fix this.