### PR TITLE
Log Fail: Return Non-Zero Exit Code

### DIFF
--- a/test_util.py
+++ b/test_util.py
@@ -238,7 +238,7 @@ class Log(object):
             email_developers()
 
         self.close_log()
-        sys.exit()
+        sys.exit(1)
 
     def testfail(self, string):
         nstr = self.fail_color + string + self.end_color


### PR DESCRIPTION
Return a non-zero exit code on failed tests/builds/etc.
This avoids that CI returns success in commonly automated settings.

Backport of https://github.com/AMReX-Codes/regression_testing/pull/89