### PR TITLE
[Backport] Python: Script Error is Test Error

### DIFF
--- a/regtest.py
+++ b/regtest.py
@@ -801,7 +801,7 @@ def test_suite(argv):
                     test.nlevels = ""
 
             if not test.doComparison:
-                test.compare_succesful = not test.crashed
+                test.compare_successful = not test.crashed
 
             if args.make_benchmarks is None and test.doComparison:
 

--- a/regtest.py
+++ b/regtest.py
@@ -800,6 +800,9 @@ def test_suite(argv):
                 if not type(params.convert_type(test.nlevels)) is int:
                     test.nlevels = ""
 
+            if not test.doComparison:
+                test.compare_succesful = not test.crashed
+
             if args.make_benchmarks is None and test.doComparison:
 
                 suite.log.log("doing the comparison...")


### PR DESCRIPTION
Make sure we report crashes as failures, even if pltfile comparisons are off.

Backport a part of https://github.com/AMReX-Codes/regression_testing/pull/57:
- https://github.com/AMReX-Codes/regression_testing/pull/57/commits/783c38dd1abda2f145eccbae318517e3a944ccca

Similar to #18